### PR TITLE
Fix: use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -1,7 +1,7 @@
 name: Create new Git Tag when PR is merged
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
 


### PR DESCRIPTION
used pull_request instead of pull_request_target so that pushed git tags can correctly trigger the build workflow